### PR TITLE
Configuration to allow ignoring GTM items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,22 @@
 
 Provides step definitions to check GTM implementation on web pages
 
-```
-DennisDigital\Behat\Gtm\Context\GtmContext
-```
-
 ## Installation
 
 ```
 composer require dennisdigital/behat-gtm
+```
+
+### Configuration
+Setup extension by specifying your behat.yml:
+
+Example on how to add extension and configure items to be ignored.
+```yaml
+default:
+  extensions:
+    DennisDigital\Behat\Gtm\Context\GtmContext:
+      ignoreGtmItems:
+        - gtm.element
 ```
 
 ## Step Definitions


### PR DESCRIPTION
**Problem**
Selenium Driver is not capable of returning certain items from the dataLayer object, example
<img width="1216" alt="Screenshot 2023-10-12 at 12 46 12" src="https://github.com/dennisinteractive/behat-gtm/assets/2162363/1dc24696-f7c8-4fe8-a235-dd1f477b39a2">

**Solution**
Added new configuration to allow ignoring dataLayer items